### PR TITLE
Allow CI to go as far as it can

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     name: Erlang/OTP ${{matrix.triplet.otp}} / rebar3 ${{matrix.triplet.rebar3}}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         triplet:
           - otp: '25'
@@ -42,6 +43,7 @@ jobs:
     name: Generate `ex_doc` for `priv`
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         triplet:
@@ -80,6 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: gen_ex_doc
     strategy:
+      fail-fast: false
       matrix:
         pair:
           - otp: '25'

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 27.0
-elixir 1.17.1-otp-27
+elixir 1.17.2-otp-27


### PR DESCRIPTION
Something's failing with `latest`, in CI, and I wanna make sure we can debug as best we can, so we move to `fail-fast: false`.