### PR TITLE
Update release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -e
 
-OTP_RAW_VER=$(erl -eval 'erlang:display(erlang:system_info(otp_release)), halt().'  -noshell)
-OTP_VER=$(echo "${OTP_RAW_VER}" | sed -r 's/\"([0-9]+)\"/\1/g' | sed 's/[^0-9]*//g')
-EXPECTED_OTP=("24" "25" "26" "27")
+EXPECTED_OTP=("25" "26" "27")
 
 yes_or_exit() {
     while true; do
@@ -15,11 +13,6 @@ yes_or_exit() {
     done
 }
 
-if [ "${OTP_VER}" -lt "24" ]; then
-     echo "You are using Erlang/OTP ${OTP_VER}."
-     echo "However, ex_doc must be built using OTP >= 24 for compatibility. Giving up..."
-     exit
-fi
 
 VERSION=$1
 
@@ -48,22 +41,24 @@ fi
 git checkout "v${VERSION}"
 
 EX_DOC_VER="v$(grep -m1 "@ex_doc_version" mix.exs | awk '{print $2}' | tr -d '"')"
-echo "Fetching ex_doc ${EX_DOC_VER} escript from GitHub ..."
-curl -L -o ex_doc_otp_${OTP_VER} "https://github.com/elixir-lang/ex_doc/releases/download/${EX_DOC_VER}/ex_doc_otp_${OTP_VER}"
-curl -L -o ex-doc-otp-${OTP_VER}.sha256sum  "https://github.com/elixir-lang/ex_doc/releases/download/${EX_DOC_VER}/ex-doc-otp-${OTP_VER}.sha256sum"
 
-echo "Validating integrity of ex_doc download..."
+for OTP_VER in "${EXPECTED_OTP[@]}"
+do
+  echo "Fetching ex_doc ${EX_DOC_VER} escript from GitHub for OTP ${OTP_VER} ..."
+  curl -L -o ex_doc_otp_${OTP_VER} "https://github.com/elixir-lang/ex_doc/releases/download/${EX_DOC_VER}/ex_doc_otp_${OTP_VER}"
+  curl -L -o ex-doc-otp-${OTP_VER}.sha256sum  "https://github.com/elixir-lang/ex_doc/releases/download/${EX_DOC_VER}/ex-doc-otp-${OTP_VER}.sha256sum"
 
-sha256sum -c ex-doc-otp-${OTP_VER}.sha256sum
+  echo "Validating integrity of ex_doc download..."
 
-chmod +x ex_doc_otp_${OTP_VER}
-mv ex_doc_otp_${OTP_VER} priv
-mv  ex-doc-otp-${OTP_VER}.sha256sum priv
+  sha256sum -c ex-doc-otp-${OTP_VER}.sha256sum
 
-echo "Looks good!"
-
-SIZE=$(du -ah priv/ex_doc_otp_${OTP_VER} | awk '{print $1}')
-echo "Size of priv/ex_doc_otp_${OTP_VER}: $SIZE"
+  chmod +x ex_doc_otp_${OTP_VER}
+  mv ex_doc_otp_${OTP_VER} priv
+  mv  ex-doc-otp-${OTP_VER}.sha256sum priv
+  echo "Looks good!"
+  SIZE=$(du -ah priv/ex_doc_otp_${OTP_VER} | awk '{print $1}')
+  echo "Size of priv/ex_doc_otp_${OTP_VER}: $SIZE"
+done
 
 rebar3 ex_doc
 
@@ -79,10 +74,10 @@ open doc/index.html
 echo
 yes_or_exit  "Did everything look ok?"
 
-for OTP in "${EXPECTED_OTP[@]}"
+for OTP_VER in "${EXPECTED_OTP[@]}"
 do
-    if [ ! -f "priv/ex_doc_otp_${OTP}" ]; then
-        echo "Expected file 'priv/ex_doc_otp_${OTP}' does not exist."
+    if [ ! -f "priv/ex_doc_otp_${OTP_VER}" ]; then
+        echo "Expected file 'priv/ex_doc_otp_${OTP_VER}' does not exist."
         exit 1
     fi
 done


### PR DESCRIPTION
The current version in the repository will only download the version of OTP being used. At this point, and per changes made in previous endeavors in both ex_doc and rebar3_ex_doc we no longer need to build and ship a version compatible with many versions of OTP. 

The changes in this commit simply adjust to iterate over all supported versions (per ex_doc builds). 