### PR TITLE
Fix assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ For further customization, see the configuration for `rebar3_ex_doc`:
 ```
 
 Please see the `ex_doc` [configuration documentation](https://hexdocs.pm/ex_doc/Mix.Tasks.Docs.html#module-configuration) for a complete overview of available configuration directives.
+Note that `"assets"` can be replaced with a map from source to target directories.
 
 You may also use an external config file by specifying a path instead of a proplist. See `ex_doc --help` for more info.
 

--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -338,6 +338,10 @@ to_ex_doc_format(ExDocOpts0) ->
     lists:foldl(
         fun ({api_reference = K, APIReference}, Opts) ->
                 [{K, APIReference} | Opts];
+            ({assets = K, Assets}, Opts) when is_map(Assets) ->
+                [{K, maps:fold(fun(Src, Target, Acc) ->
+                                   Acc#{to_binary(Src) => to_binary(Target)}
+                               end, #{}, Assets)} | Opts];
             ({assets = K, Assets}, Opts) ->
                 [{K, to_binary(Assets)} | Opts];
             ({extras = K, Extras}, Opts) ->

--- a/test/rebar3_ex_doc_SUITE.erl
+++ b/test/rebar3_ex_doc_SUITE.erl
@@ -23,6 +23,7 @@ all_post_27(OTPRelease) when OTPRelease >= 27 ->
         generate_docs_post_27,
         generate_docs_alternate_rebar3_config_format_post_27,
         generate_docs_without_extra_post_27,
+        generate_docs_with_legacy_assets_post_27,
         generate_docs_with_current_app_set_post_27,
         generate_docs_with_bad_config_post_27,
         generate_docs_with_alternate_ex_doc_post_27,
@@ -70,6 +71,9 @@ generate_docs_without_extra_post_27(Config) ->
 
 generate_docs_overriding_output_set_in_config_post_27(Config) ->
     generate_docs_overriding_output_set_in_config([{post_27, true} | Config]).
+
+generate_docs_with_legacy_assets_post_27(Config) ->
+    generate_docs_with_assets([{legacy_assets, true}, {post_27, true} | Config]).
 
 generate_docs(Config) ->
     Post27 = proplists:get_value(post_27, Config, false),
@@ -123,6 +127,28 @@ generate_docs_without_extra(Config) ->
         dir => data_dir(Config),
         name => "no_extra_docs",
         config => {ex_doc,[]}
+    },
+    {State, App} = make_stub(Post27, StubConfig),
+
+    ok = make_readme(App),
+    ok = make_license(App),
+    {ok, _} = rebar3_ex_doc:do(State),
+    check_docs(App, State, StubConfig).
+
+generate_docs_with_assets(Config) ->
+    Post27 = proplists:get_value(post_27, Config, false),
+    Assets =
+      case proplists:get_value(legacy_assets, Config, false) of
+          true -> "src";
+          false -> #{"src" => "assets"}
+      end,
+    StubConfig = #{
+        app_src => #{version => "0.1.0"},
+        dir => data_dir(Config),
+        name => "assets_docs",
+        config =>
+            {ex_doc,[{main,"README.md"},
+                     {assets, Assets}]}
     },
     {State, App} = make_stub(Post27, StubConfig),
 
@@ -326,6 +352,7 @@ mermaid_before_before_closing_body_tag(Config) ->
 
 check_docs(App, State, #{config := {ex_doc, DocConfig}} = _Stub) ->
     Extras = format_extras(proplists:get_value(extras, DocConfig, [])),
+    Assets = proplists:get_value(assets, DocConfig),
     AppDir = rebar_app_info:dir(App),
     BuildDir = filename:join(AppDir, "_build"),
     {ok, ConfigFile} = file:consult(filename:join([BuildDir, "default/lib/", rebar_app_info:name(App), "doc/docs.config"])),


### PR DESCRIPTION
Ex doc seems to deal differently with assets these days and accepts a map with source -> target entries.

In order to fix that, I added two tests that for checking that assets are created.
One that checks that the legacy form can still be used and one that checks that the new version works.
I have also improved the default testing by not depending on "extras" in all configs.
