### PR TITLE
ex_doc version v0.38.1 demands KeyWords instead of Maps

### DIFF
--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -400,6 +400,7 @@ to_ex_doc_format_extras(Extras0) ->
     ).
 
 to_ex_doc_format_extras_opts(Extras) ->
+    maps:to_list(
     maps:map(
         fun (filename, Filename) ->
                 to_binary(Filename);
@@ -410,7 +411,7 @@ to_ex_doc_format_extras_opts(Extras) ->
                 Value
         end,
         Extras
-    ).
+    )).
 
 to_binary(Term) when is_list(Term) ->
     list_to_binary(Term);

--- a/test/rebar3_ex_doc_SUITE.erl
+++ b/test/rebar3_ex_doc_SUITE.erl
@@ -448,6 +448,7 @@ format_extras(Extras0) ->
     ).
 
 format_extras_opts(Extras) ->
+    maps:to_list(
     maps:map(
         fun (filename, Filename) when is_list(Filename) ->
                 list_to_binary(Filename);
@@ -457,7 +458,7 @@ format_extras_opts(Extras) ->
                 Value
         end,
         Extras
-    ).
+    )).
 
 compile_src_file(App) ->
     Dir = rebar_app_info:dir(App),


### PR DESCRIPTION
Since this commit:
https://github.com/elixir-lang/ex_doc/commit/15f3a593898647800b9b9ba6660696dfa7ff4a0a sending in a map would no longer work, it is a keyword list that is expected for the extra arguments.

That is why the tests fail in the repository for version 0.2.27.

I am a bit unhappy that the code for creating the options is just a copy in both test and production code. The comparison `?assertMatch(Extra, ExpExtra)` is in that sense just a comparison between two different copies of the code and do not relate to the code that `ex_doc` expects.
I did not want to rewrite that part of the code, because it has nothing to do with the actual failure itself.