### PR TITLE
Add markdown to default documentation formats

### DIFF
--- a/src/rebar3_ex_doc.erl
+++ b/src/rebar3_ex_doc.erl
@@ -452,7 +452,7 @@ ex_doc_opts_defaults(Opts) ->
 maybe_add_opt(formatter, Opts) ->
     case proplists:get_all_values(formatter, Opts) of
         [] ->
-            ["-f", "html", "-f", "epub"];
+            ["-f", "html", "-f", "markdown", "-f", "epub"];
         [Formatter] ->
             ["-f", Formatter];
         Formatters ->
@@ -561,9 +561,9 @@ help(canonical) ->
 help(output) ->
     "Output directory for the generated docs.";
 help(formatter) ->
-    "Which formatters to use, \"html\" or \"epub\"."
+    "Which formatters to use, \"html\", \"markdown\", or \"epub\"."
     "This option can be given more than once."
-    "By default, both html and epub are generated.";
+    "By default, html, markdown and epub are generated.";
 help(language) ->
     "Identify the primary language of the documents,"
     "its value must be a valid BCP 47 language tag."


### PR DESCRIPTION
## Summary

- add `markdown` between the existing `html` and `epub` default formatters
- list `markdown` in `--formatter` help and keep the documented default accurate

ex_doc 0.40 added Markdown output and `llms.txt`, but this plugin's explicit default still passes only HTML and EPUB. [`observer_cli` already opts in explicitly](https://github.com/zhongwencool/observer_cli/blob/fd5fb50adae142f32d3783c6dbc744485badacd3/rebar.config#L84-L87) with `--formatter markdown`, demonstrating that the formatter is supported; this change makes it part of the plugin default.

This PR was generated from the [Elixir retrieval gap report](https://phxagents.dev/research/elixir-retrieval-gap/), which identified the plugin default and help text as the Erlang-side rollout gap.

## Verification

On unmodified `upstream/main` and again after this change:

- `mix deps.get && mix escript.build` — passed
- `rebar3 ct` — all 19 tests passed
- `rebar3 dialyzer` — passed
- `mix docs` — generated HTML, Markdown/`llms.txt`, and EPUB output (with the same two existing undefined callback-reference warnings)

A checkout-backed fixture also confirmed that `rebar3 help ex_doc` lists all three formatters and the default `rebar3 ex_doc` run generates `index.html`, `llms.txt`, and an EPUB.

— Oliver’s AMP